### PR TITLE
fix: Bug in rendering CF problems that don't have a contestId

### DIFF
--- a/modules/apiHandler.py
+++ b/modules/apiHandler.py
@@ -179,9 +179,10 @@ class ApiCaller:
             for submission in data:
                 verdict = submission['verdict']
                 if(verdict == "OK"):
-                    contestId = submission['problem']['contestId']
-                    problemId = submission['problem']['index']
-                    solves.add(str(contestId) + str(problemId))
+                    if submission['problem'].get('contestId'):
+                        contestId = submission['problem']['contestId']
+                        problemId = submission['problem']['index']
+                        solves.add(str(contestId) + str(problemId))
             return solves
         else:
             print("Couldn't fetch submissions.")


### PR DESCRIPTION
The script was giving keyError for CF problems that didn't have a contestId, such as acmsguru problem. I've fixed it by ignoring it. acmsguru problems need to be submitted manually. These problems can also be submitted, but the submission url will need to be changed.